### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Set applicationUrl to your domain.
 
 Pass values from the server to the client via `DEFAULT_SETTINGS`. This code can be found in index.ejs.
 
-####ngrok
+#### ngrok
 Ngrok makes it easy to provide a public url to an application running on your local machine. This
 comes in handy when dealing with OAuth providers that don't permit localhost. Install ngrok - https://ngrok.com/
 and then run two instances one for the node server and another for the webpack server:


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
